### PR TITLE
declare property to remove php 8.3 deprecated warning

### DIFF
--- a/tests/tool_deletemessage_test.php
+++ b/tests/tool_deletemessage_test.php
@@ -36,6 +36,9 @@ namespace tool_deletemessage;
  */
 class tool_deletemessage_test extends \advanced_testcase {
 
+    /* @var $messagesink message sink */
+    private $messagesink;
+
     /**
      * Test set up.
      *


### PR DESCRIPTION
We have seen deprecated warnings come up when using php 8.3 as the property on the test class does not exist